### PR TITLE
add namespace to metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Metrics look like this..
 ```
 # HELP helm_chart_info Helm chart information
 # TYPE helm_chart_info gauge
-helm_chart_info{name="nginx-ingress",version="0.28.2"} 1.0
-helm_chart_info{name="kubedex-exporter",version="0.0.1"} 1.0
-helm_chart_info{name="prometheus",version="7.0.3"} 1.0
-helm_chart_info{name="grafana",version="1.14.6"} 1.0
+helm_chart_info{name="nginx-ingress",version="0.28.2",namespace="infra"} 1.0
+helm_chart_info{name="kubedex-exporter",version="0.0.1",namepspace="infra"} 1.0
+helm_chart_info{name="prometheus",version="7.0.3", namespace="monitoring"} 1.0
+helm_chart_info{name="grafana",version="1.14.6",namespace="monitoring"} 1.0
 ```
 
 This dynamically updates as you add and remove charts.

--- a/src/kubedex.py
+++ b/src/kubedex.py
@@ -40,9 +40,13 @@ class CustomCollector(object):
                 print(e)
                 continue
         metric = Metric('helm_chart_info', 'Helm chart information', 'gauge')
-        chart_count = Counter([(release.chart.metadata.name, release.chart.metadata.version) for release in all_releases])
+        chart_count = Counter([(release.chart.metadata.name, release.chart.metadata.version, release.namespace) for release in all_releases])
         for chart in chart_count:
-            metric.add_sample('helm_chart_info', value=chart_count[chart], labels={"name": chart[0], "version": chart[1]})
+            metric.add_sample(
+                    'helm_chart_info', 
+                    value=chart_count[chart], 
+                    labels={"name": chart[0], "version": chart[1], "namespace": chart[2]}
+             )
         yield metric
 
 


### PR DESCRIPTION
This shows the namespace of a release in the metric. So one is able to filter the helm releases by namespace in the Grafana panel.